### PR TITLE
Adding python2-jmespath as dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Requirements
 * Ansible has to be 2.5 or higher.
 * [ovirt-imageio](http://www.ovirt.org/develop/release-management/features/storage/image-upload/) must be installed and running.
 * [oVirt Python SDK version 4](https://pypi.python.org/pypi/ovirt-engine-sdk-python/4.2.4).
+* python2-jmespath
 
 Additionally, perform the following checks to ensure the required processes are running.
 * Check whether `ovirt-imageio-proxy` is running on the engine:


### PR DESCRIPTION
If you don't have this package installed, you'll get this error:

> TASK [oVirt.manageiq : Find data domain] 
> task path: /home/jan/repo/ovirt-ansible-manageiq/tasks/main.yml:40
> fatal: [localhost]: FAILED! => {"msg": "You need to install \"jmespath\" prior to running json_query filter"}