### PR TITLE
Fix miq app password

### DIFF
--- a/tasks/cfme_add_disk.yml
+++ b/tasks/cfme_add_disk.yml
@@ -10,5 +10,6 @@
     storage_domain: "{{ miq_vm_disks[item].storage | default(miq_vm_disk_storage) | default(disk_storage_domain.name) }}"
 
 - name: Add {{ item }} disk to CloudForms initialization command
+  no_log: true
   set_fact:
     miq_init_cmd2: "{{ miq_init_cmd2 }} {{ miq_init_cmd_options.disks[item] }} {{ miq_vm_disks_devices[item] }}"

--- a/tasks/init_cfme.yml
+++ b/tasks/init_cfme.yml
@@ -1,4 +1,5 @@
 - name: Add host alias of appliance
+  no_log: true
   add_host:
     hostname: "{{ miq_ip_addr }}"
     ansible_host: "{{ miq_ip_addr }}"

--- a/tasks/wait_for_api.yml
+++ b/tasks/wait_for_api.yml
@@ -23,7 +23,7 @@
     body:
       action: "edit"
       resource:
-        password: "{{ miq_app_password }}"
+        password: "{{ miq_app_password | string }}"
   register: miq_admin_password
   changed_when: "miq_admin_password.status == 201 or miq_admin_password.status == 200"
   failed_when:


### PR DESCRIPTION
When int was specified as `miq_app_password` it failed server side on MiQ, this patch add cast to string.