### PR TITLE
Add miq_wait_for_ip_version variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Virtual machine variables:
 | miq_vm_high_availability_priority | 50      | Indicates the priority of the virtual machine inside the run and migration queues. The value is an integer between 0 and 100. The higher the value, the higher the priority. |
 | miq_vm_delete_protected | true              | If yes ManageIQ virtual machine will be set as delete protected. |
 | miq_debug_create        | false             | If true log sensitive data, useful for debug purposes.           |
+| miq_wait_for_ip_version  | v4               | Specify which IP version should be wait for. Either v4 or v6.  |
 
 Virtual machine main disks variables (e.g. operating system):
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 ### This option disables no_log of tasks using sensistive data:
 miq_debug_create: false
 
+### Wait for IP version (v4 or v6):
+miq_wait_for_ip_version: v4
+
 ### ManageIQ/CloudForms ###
 miq_image_path: /tmp
 

--- a/filter_plugins/ovirtvmip.py
+++ b/filter_plugins/ovirtvmip.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python
+'Module to create filter to find IP addresses in VMs'
 class FilterModule(object):
+    'Filter for IP addresses on newly created VMs'
     def filters(self):
+        'Define filters'
         return {
             'ovirtvmip': self.ovirtvmip,
             'ovirtvmips': self.ovirtvmips,
@@ -9,23 +12,29 @@ class FilterModule(object):
             'ovirtvmipv6': self.ovirtvmipv6,
             'ovirtvmipsv6': self.ovirtvmipsv6,
         }
- 
+
     def ovirtvmip(self, ovirt_vms, attr=None):
+        'Return first IP'
         return self.__get_first_ip(self.ovirtvmips(ovirt_vms, attr))
 
     def ovirtvmips(self, ovirt_vms, attr=None):
+        'Return list of IPs'
         return self._parse_ips(ovirt_vms, attr=attr)
 
     def ovirtvmipv4(self, ovirt_vms, attr=None):
+        'Return first IPv4 IP'
         return self.__get_first_ip(self.ovirtvmipsv4(ovirt_vms, attr))
 
     def ovirtvmipsv4(self, ovirt_vms, attr=None):
+        'Return list of IPv4 IPs'
         return self._parse_ips(ovirt_vms, lambda version: version == 'v4', attr)
 
     def ovirtvmipv6(self, ovirt_vms, attr=None):
+        'Return first IPv6 IP'
         return self.__get_first_ip(self.ovirtvmipsv6(ovirt_vms, attr))
 
     def ovirtvmipsv6(self, ovirt_vms, attr=None):
+        'Return list of IPv6 IPs'
         return self._parse_ips(ovirt_vms, lambda version: version == 'v6', attr)
 
     def _parse_ips(self, ovirt_vms, version_condition=lambda version: True, attr=None):
@@ -37,25 +46,28 @@ class FilterModule(object):
         else:
             return self._parse_ips_asdict(ovirt_vms, version_condition, attr)
 
-    def _parse_ips_asdict(self, ovirt_vms, version_condition=lambda version: True, attr=None):
+    @staticmethod
+    def _parse_ips_asdict(ovirt_vms, version_condition=lambda version: True, attr=None):
         vm_ips = {}
         for ovirt_vm in ovirt_vms:
             ips = []
             for device in ovirt_vm.get('reported_devices', []):
-                for ip in device.get('ips', []):
-                    if version_condition(ip.get('version')):
-                        ips.append(ip.get('address'))
+                for curr_ip in device.get('ips', []):
+                    if version_condition(curr_ip.get('version')):
+                        ips.append(curr_ip.get('address'))
             vm_ips[ovirt_vm.get(attr)] = ips
         return vm_ips
 
-    def _parse_ips_aslist(self, ovirt_vms, version_condition=lambda version: True):
+    @staticmethod
+    def _parse_ips_aslist(ovirt_vms, version_condition=lambda version: True):
         ips = []
         for ovirt_vm in ovirt_vms:
             for device in ovirt_vm.get('reported_devices', []):
-                for ip in device.get('ips', []):
-                    if version_condition(ip.get('version')):
-                        ips.append(ip.get('address'))
+                for curr_ip in device.get('ips', []):
+                    if version_condition(curr_ip.get('version')):
+                        ips.append(curr_ip.get('address'))
         return ips
 
-    def __get_first_ip(self, res):
+    @staticmethod
+    def __get_first_ip(res):
         return res[0] if isinstance(res, list) and res else res

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,19 +61,28 @@
         name: "{{ miq_vm_name }}"
         cloud_init: "{{ miq_vm_cloud_init | default(omit) }}"
 
+    - set_fact:
+        ip_cond: "ovirt_vms | ovirtvmip{{ miq_wait_for_ip_version }} | length > 0"
+
     - name: Wait for VM IP
       ovirt_vms_facts:
         auth: "{{ ovirt_auth }}"
         pattern: "name={{ miq_vm_name }}"
         fetch_nested: true
         nested_attributes: ips
-      until: ovirt_vms | map(attribute='reported_devices') | list | first | length > 0
+      until: "ip_cond"
       retries: 10
       delay: 10
 
-    - name: ManageIQ host IP address
+    - name: ManageIQ host IPv4 address
       set_fact:
         miq_ip_addr: "{{ ovirt_vms | ovirtvmipv4 }}"
+      when: miq_wait_for_ip_version == 'v4'
+
+    - name: ManageIQ host IPv6 address
+      set_fact:
+        miq_ip_addr: "{{ ovirt_vms | ovirtvmipv6 }}"
+      when: miq_wait_for_ip_version == 'v6'
 
     - block:
       - include: init_cfme.yml


### PR DESCRIPTION
This fixes the issue when IPv6 is reported sooner than IPv4, user can
now choose which IP he want to wait for.

Change-Id: I2756d9fbd42f588a7c20ca3d764bb8f95cab63ec
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1613723
Signed-off-by: Ondra Machacek <omachace@redhat.com>