### PR TITLE
Skip region settings in case of ManageIQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ ManageIQ variables:
 | miq_password       | smartvm             | Alias of `miq_app_password` for backward compatibility.                    |
 | miq_db_username    | root                | The username to connect to the database.                                   |
 | miq_db_password    | `miq_app_password`  | The password of user specific in username used to connect to the database. |
-| miq_region         | 0                   | The ManageIQ region created in the database.                               |
+| miq_region         | 0                   | The ManageIQ region created in the database. Note: Works only with CFME.   |
 | miq_company        | My Company          | The company name of the appliance.                                         |
 | miq_disabled_roles | []                  | List of ManageIQ server roles to disable on the appliance.                 |
 | miq_enabled_roles  | []                  | List of ManageIQ server roles to enable on the appliance.                  |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ miq_db_password: "{{ miq_app_password }}"
 
 # ManageIQ/CloudForms region
 miq_region: 0
-miq_region_id: "{{ miq_region|int * 1000000000000  + 1 }}"
+miq_region_id: 1
 
 # ManageIQ/CloudForms company name
 miq_company: My Company

--- a/tasks/init_cfme.yml
+++ b/tasks/init_cfme.yml
@@ -23,9 +23,15 @@
   changed_when: false
   delegate_to: "{{ miq_ip_addr }}"
 
-- name: Initialize CloudForms
-  command: "{{ miq_init_cmd2 }}"
-  delegate_to: "{{ miq_ip_addr }}"
+- block:
+  - name: Set region id
+    set_fact:
+      miq_region_id: "{{ miq_region|int * 1000000000000  + 1 }}"
+
+  - name: Initialize CloudForms
+    command: "{{ miq_init_cmd2 }}"
+    delegate_to: "{{ miq_ip_addr }}"
+
   when: "cfme_rpm.rc == 0"
 
 - name: Set root password of appliance


### PR DESCRIPTION
ManageIQ is preconfigured and so we can't set region ID.

Change-Id: I45da1e8ca6b81a997f4ad5aa25fcc72657934419
Signed-off-by: Ondra Machacek <omachace@redhat.com>