### PR TITLE
Change documentation so it uses virtio_scsi

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ For each disk, the following attributes can be set:
 |-----------|---------------|----------------------------------------------------------------------|
 | name      | `miq_vm_name`_`type` | The name of the virtual machine disk.                 |
 | size      | UNDEF         | The virtual machine disk size (`XXGiB`).                             |
-| interface | UNDEF         | The virtual machine disk interface type (`virtio` or `virtio_scsi`). |
+| interface | virtio_scsi   | The virtual machine disk interface type (`virtio` or `virtio_scsi`). `virtio_scsi` is recommended, as `virtio` has low limit of count of disks. |
 | format    | UNDEF         | The format of the virtual machine disk (`raw` or `cow`).             |
 | timeout   | UNDEF         | Timeout of disk creation.                                            |
 
@@ -110,7 +110,7 @@ The item in `miq_vm_nics` list of can contain following attributes:
 | Name               | Default value  |                                              |
 |--------------------|----------------|----------------------------------------------|
 | name               | UNDEF          | The name of the network interface.           |
-| interface          | UNDEF          | Type of the network interface.               |
+| interface          | UNDEF          | Type of the network interface.              |
 | mac_address        | UNDEF          | Custom MAC address of the network interface, by default it's obtained from MAC pool. |
 | network            | UNDEF          | Logical network which the VM network interface should use. If network is not specified, then Empty network is used. |
 | profile            | UNDEF          | Virtual network interface profile to be attached to VM network interface. |
@@ -188,17 +188,17 @@ Here is an example how to deploy CFME:
           database:
             name: "{{ miq_vm_name }}_database"
             size: 10GiB
-            interface: virtio
+            interface: virtio_scsi
             format: raw
           log:
             name: "{{ miq_vm_name }}_log"
             size: 10GiB
-            interface: virtio
+            interface: virtio_scsi
             format: cow
           tmp:
             name: "{{ miq_vm_name }}_tmp"
             size: 10GiB
-            interface: virtio
+            interface: virtio_scsi
             format: cow
         miq_disabled_roles:
           - smartstate

--- a/examples/cfme.yml
+++ b/examples/cfme.yml
@@ -23,17 +23,17 @@
       database:
         name: "{{ miq_vm_name }}_database"
         size: 10GiB
-        interface: virtio
+        interface: virtio_scsi
         format: raw
       log:
         name: "{{ miq_vm_name }}_log"
         size: 10GiB
-        interface: virtio
+        interface: virtio_scsi
         format: cow
       tmp:
         name: "{{ miq_vm_name }}_tmp"
         size: 10GiB
-        interface: virtio-scsi
+        interface: virtio_scsi
         format: raw
     miq_disabled_roles:
       - smartstate

--- a/tasks/cfme_add_disk.yml
+++ b/tasks/cfme_add_disk.yml
@@ -3,7 +3,7 @@
     auth: "{{ ovirt_auth }}"
     name: "{{ miq_vm_disks[item].name | default(miq_vm_name ~ '_' ~ item) }}"
     vm_name: "{{ miq_vm_name }}"
-    interface: "{{ miq_vm_disks[item].interface | default(omit) }}"
+    interface: "{{ miq_vm_disks[item].interface | default('virtio_scsi') }}"
     size: "{{ miq_vm_disks[item].size | default(omit) }}"
     format: "{{ miq_vm_disks[item].format | default(omit) }}"
     timeout: "{{ miq_vm_disks[item].timeout | default(omit) }}"


### PR DESCRIPTION
virtio-blk has it's limits in terms of count of devices (25). It's
better to use virtio-scsi instead, as there are no big perfomance
difference and virtio-scsi doesn't have such low limits. More info:

 https://wiki.qemu.org/images/c/c2/Virtio-scsi.pdf

Change-Id: Ia4945fbd40780ddf8b25841aac7310daf3443f9c
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1627026
Signed-off-by: Ondra Machacek <omachace@redhat.com>