### PR TITLE
Workaround: disk activation for deploying CFME

### DIFF
--- a/tasks/cfme_add_disk.yml
+++ b/tasks/cfme_add_disk.yml
@@ -8,6 +8,7 @@
     format: "{{ miq_vm_disks[item].format | default(omit) }}"
     timeout: "{{ miq_vm_disks[item].timeout | default(omit) }}"
     storage_domain: "{{ miq_vm_disks[item].storage | default(disk_storage_domain.name if disk_storage_domain is defined else miq_vm_disk_storage) }}"
+    activate: yes
 
 - name: Add {{ item }} disk to CloudForms initialization command
   no_log: "{{ not miq_debug_create }}"


### PR DESCRIPTION
Workaround for issue with disk activation after its creation described here: https://github.com/ansible/ansible/pull/57464

Disabled disks (especially DB disk for CFME) cause failed deployment of CFME in task Wait for Api, which ends with timeout issue. Fix in Ansible should be available in couple of weeks.