### PR TITLE
ovirt-ansible-manageiq-1.1: automation update

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -1,6 +1,4 @@
 distros:
-  - fc29
-  - fc28
   - el7
 release_branches:
-  master: [ "ovirt-master", "ovirt-4.3", "ovirt-4.2" ]
+  ovirt-ansible-manageiq-1.1: [ "ovirt-4.3", "ovirt-4.2" ]


### PR DESCRIPTION
Create a new branch for an older version of the project where users still can use ansible under 2.9

https://bugzilla.redhat.com/show_bug.cgi?id=1762259
@machacekondra @mwperina