### PR TITLE
ovirt-ansible-manageiq: bump ansible to 2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Requirements
 ------------
 
 * oVirt has to be 4.0.4 or higher.
-* Ansible has to be 2.5 or higher.
+* Ansible has to be 2.9 or higher.
 * [ovirt-imageio](http://www.ovirt.org/develop/release-management/features/storage/image-upload/) must be installed and running.
 * [oVirt Python SDK version 4](https://pypi.python.org/pypi/ovirt-engine-sdk-python/4.2.4).
 

--- a/automation.yaml
+++ b/automation.yaml
@@ -1,6 +1,5 @@
 distros:
-  - fc29
-  - fc28
+  - fc30
   - el7
 release_branches:
-  master: [ "ovirt-master", "ovirt-4.3", "ovirt-4.2" ]
+  master: [ "ovirt-master" ]

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="1.1.15"
+VERSION="1.2.0"
 MILESTONE=master
 RPM_RELEASE="0.1.$MILESTONE.$(date -u +%Y%m%d%H%M%S)"
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
 
   license: Apache License 2.0
 
-  min_ansible_version: 2.5
+  min_ansible_version: 2.9
 
   platforms:
   - name: EL

--- a/ovirt-ansible-manageiq.spec.in
+++ b/ovirt-ansible-manageiq.spec.in
@@ -14,7 +14,7 @@ Group:          Virtualization/Management
 BuildArch:      noarch
 Url:            http://www.ovirt.org
 
-Requires: ansible >= 2.7.2
+Requires: ansible >= 2.9.0
 
 %description
 This Ansible role provide funtionality to create ManageIQ or CloudForms virtual

--- a/tasks/deploy_qcow2.yml
+++ b/tasks/deploy_qcow2.yml
@@ -43,21 +43,23 @@
 #
 - block:
   - name: Fetch storages
-    ovirt_storage_domain_facts:
+    ovirt_storage_domain_info:
       auth: "{{ ovirt_auth }}"
       pattern: "Clusters.name={{ miq_vm_cluster }} and status=active"
+    register: sd_info
 
   - name: Find data domain
     set_fact:
-      disk_storage_domain: "{{ ovirt_storage_domains | json_query(the_query) | list | first }}"
+      disk_storage_domain: "{{ sd_info.ovirt_storage_domains | json_query(the_query) | list | first }}"
     vars:
       the_query: "[?type=='data']"
   when: miq_vm_disk_storage is undefined
 
 - name: Check if VM already exists
-  ovirt_vm_facts:
+  ovirt_vm_info:
     auth: "{{ ovirt_auth }}"
     pattern: "name={{ miq_vm_name }}"
+  register: vm_info
 
 - block:
   - name: Deploy the qcow image to oVirt engine
@@ -69,7 +71,7 @@
       format: "{{  miq_vm_disk_format }}"
       image_path: "{{ downloaded_file.dest }}"
       storage_domain: "{{ disk_storage_domain.name if disk_storage_domain is defined else miq_vm_disk_storage }}"
-      force: "{{ ovirt_vms | length == 0 }}"
+      force: "{{ vm_info.ovirt_vms | length == 0 }}"
     register: ovirt_disk
 
   rescue:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,10 +69,10 @@
         cloud_init: "{{ miq_vm_cloud_init | default(omit) }}"
 
     - set_fact:
-        ip_cond: "ovirt_vms | ovirtvmip{{ miq_wait_for_ip_version }} | length > 0"
+        ip_cond: "vm_info.ovirt_vms | ovirtvmip{{ miq_wait_for_ip_version }} | length > 0"
 
     - name: Wait for VM IP
-      ovirt_vm_facts:
+      ovirt_vm_info:
         auth: "{{ ovirt_auth }}"
         pattern: "name={{ miq_vm_name }}"
         fetch_nested: true
@@ -80,15 +80,16 @@
       until: "ip_cond"
       retries: "{{ miq_wait_for_ip_timeout // 10 }}"
       delay: 10
+      register: vm_info
 
     - name: ManageIQ host IPv4 address
       set_fact:
-        miq_ip_addr: "{{ ovirt_vms | ovirtvmipv4 }}"
+        miq_ip_addr: "{{ vm_info.ovirt_vms | ovirtvmipv4 }}"
       when: miq_wait_for_ip_version == 'v4'
 
     - name: ManageIQ host IPv6 address
       set_fact:
-        miq_ip_addr: "{{ ovirt_vms | ovirtvmipv6 }}"
+        miq_ip_addr: "{{ vm_info.ovirt_vms | ovirtvmipv6 }}"
       when: miq_wait_for_ip_version == 'v6'
 
     - block:


### PR DESCRIPTION
Bump ansible to 2.9

- keep only "ovirt-master" in automation.yaml    
- bump project version to 1.2.0 in build.sh 
- change in all tasks *_facts to *_info modules because of depreciation in ansible 2.13
   - it cannot be simply renamed to _info module because it does not return ansible_facts so all variables need to be registered and then used (https://docs.ansible.com/ansible/latest/modules/ovirt_api_info_module.html#notes)
- use ansible>=2.9.0 in 
  - ovirt-ansible-manageiq.spec.in for build  
  - requirements.txt for manual install of ansible from pip
  - meta/main.yml for info in ansible galaxy
  - change ansible and sdk version in  README.md

https://bugzilla.redhat.com/show_bug.cgi?id=1762259
@machacekondra @mwperina 